### PR TITLE
Unfix table of contents

### DIFF
--- a/static/css/newstyles.css
+++ b/static/css/newstyles.css
@@ -100,7 +100,7 @@ margin-bottom: 20px;
   width: 20%;
   background-color: #fff;
   padding: 20px;
-  position: fixed;
+  position: absolute;
   z-index: 0;
   display: none;
 }


### PR DESCRIPTION
For some reason, the TOC fits the page on my local version, but overflows on the secfirst.org website. Not sure why. So I decided to make it scrollable, so that all the content is visible. 